### PR TITLE
Fix typo in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -21,7 +21,7 @@
                 "args": [
                     "build",
                     "--bin=jwtui",
-                    "--package=jwtui"
+                    "--package=jwt-ui"
                 ],
                 "filter": {
                     "name": "jwtui",
@@ -40,7 +40,7 @@
                     "test",
                     "--no-run",
                     "--bin=jwtui",
-                    "--package=jwtui"
+                    "--package=jwt-ui"
                 ],
                 "filter": {
                     "name": "jwtui",


### PR DESCRIPTION
When executing the `Debug executable 'jwtui'` defined in the launch.json, the following error will occure.

```
Running `cargo build --bin=jwtui --package=jwtui --message-format=json`...
error: package ID specification `jwtui` did not match any packages

        Did you mean `jwt-ui`?
```

The correct package name is jwt-ui that defined here.

https://github.com/jwt-rs/jwt-ui/blob/992975008f2201522bb4d8c09de3e928102e1da6/Cargo.toml#L2