### PR TITLE
Mark some fields as dead code

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -104,11 +104,16 @@ pub struct App {
   pub title: &'static str,
   pub should_quit: bool,
   pub main_tabs: TabsState,
+  #[allow(dead_code)]
   pub is_loading: bool,
+  #[allow(dead_code)]
   pub is_routing: bool,
+  #[allow(dead_code)]
   pub tick_rate: u64,
   pub size: Rect,
+  #[allow(dead_code)]
   pub dialog: Option<String>,
+  #[allow(dead_code)]
   pub confirm: bool,
   pub light_theme: bool,
   pub help_docs: StatefulTable<Vec<String>>,

--- a/src/event/events.rs
+++ b/src/event/events.rs
@@ -12,6 +12,7 @@ use super::Key;
 #[derive(Debug, Clone, Copy)]
 /// Configuration for event handling.
 pub struct EventConfig {
+  #[allow(dead_code)]
   pub exit_key: Key,
   /// The tick rate at which the application will sent an tick event.
   pub tick_rate: Duration,


### PR DESCRIPTION
Currently the CI is failing due to clippy warnings related to unread fields. This PR is an attempt to fix it.