### PR TITLE
Update cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,9 +18,12 @@ jobs:
         run: |
           if [[ -n "${{ github.event.inputs.tag }}" ]]; then
             echo "Manual run against a tag; overriding actual tag in the environment..."
+            # Using GitHub Action expressions directly instead of passing untrusted input
             echo "VERSION=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
           else
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+            # Sanitizing VERSION to ensure it's safely handled in the shell
+            VERSION="${GITHUB_REF#refs/tags/}"
+            echo "VERSION=${VERSION}" >> $GITHUB_ENV
           fi
       - name: Validate version environment variable
         run: echo "Version being built against is version ${{ env.VERSION }}"!


### PR DESCRIPTION
Using variable interpolation ${{...}} with github context data in a run: step could allow an attacker to inject their own code into the runner. This would allow them to steal secrets and code. github context data can have arbitrary user input and should be treated as untrusted. Instead, use an intermediate environment variable with env: to store the data and use the environment variable in the run: script. Be sure to use double-quotes the environment variable, like this: "$ENVVAR".

