### PR TITLE
Refine from_f function documentation and add tests

### DIFF
--- a/src/event/key.rs
+++ b/src/event/key.rs
@@ -252,6 +252,7 @@ mod tests {
       Key::Ctrl('c')
     );
   }
+
   #[test]
   fn from_f_zero_is_valid() {
       assert_eq!(Key::from_f(0), Key::F0);

--- a/src/event/key.rs
+++ b/src/event/key.rs
@@ -72,7 +72,7 @@ impl Key {
   ///
   /// # Panics
   ///
-  /// If `n == 0 || n > 12`
+  /// If `n > 12`
   pub fn from_f(n: u8) -> Key {
     match n {
       0 => Key::F0,
@@ -251,5 +251,15 @@ mod tests {
       }),
       Key::Ctrl('c')
     );
+  }
+  #[test]
+  fn from_f_zero_is_valid() {
+      assert_eq!(Key::from_f(0), Key::F0);
+  }
+
+  #[test]
+  #[should_panic(expected = "unknown function key: F13")]
+  fn from_f_above_max_panics() {
+      let _ = Key::from_f(13);
   }
 }


### PR DESCRIPTION
### Summary
This PR fixes the incorrect panic documentation in `Key::from_f` and adds tests to verify behavior.

Resolves #108